### PR TITLE
feature/handle car image

### DIFF
--- a/PocketForzaHorizonCommunity.Back/PocketForzaHorizonCommunity.Back.Services/Services/CarService.cs
+++ b/PocketForzaHorizonCommunity.Back/PocketForzaHorizonCommunity.Back.Services/Services/CarService.cs
@@ -1,4 +1,6 @@
-﻿using Microsoft.EntityFrameworkCore;
+﻿using Microsoft.AspNetCore.Http;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Configuration;
 using PocketForzaHorizonCommunity.Back.Database;
 using PocketForzaHorizonCommunity.Back.Database.Entities.CarEntities;
 using PocketForzaHorizonCommunity.Back.Database.Repos.Interfaces;
@@ -8,52 +10,68 @@ using PocketForzaHorizonCommunity.Back.Services.Services.Interfaces;
 
 namespace PocketForzaHorizonCommunity.Back.Services.Services;
 
-public class CarService : ServiceBase<ICarRepository, Car>, ICarService
+public class CarService : ServiceWithFilesBase<ICarRepository, Car>, ICarService
 {
-    public CarService(ICarRepository repository) : base(repository)
+    public CarService(ICarRepository repository, IConfiguration config) : base(repository, config)
     {
+    }
+
+    public override async Task<Car> CreateAsync(Car entity, IFormFile thumbnail)
+    {
+        await _repository.CreateAsync(entity);
+        await _repository.SaveAsync();
+
+        var path = Path.Combine(_configuration["Images:Cars"], entity.Id.ToString());
+
+        using (var stream = new FileStream(path, FileMode.Create))
+        {
+            await thumbnail.CopyToAsync(stream);
+        }
+
+        entity.ImagePath = path;
+        await _repository.SaveAsync();
+
+        return entity;
     }
 
     public async Task<PaginationModel<Car>> GetDesignsByIdAsync(Guid id, int page, int pageSize)
     {
-        var result = await _repository.GetByIdWithTunes(id).PaginateAsync(page, pageSize);
-
-        if (result == null)
-        {
-            throw new EntityNotFoundException();
-        }
-
-        return result;
+        return await _repository.GetByIdWithTunes(id).PaginateAsync(page, pageSize) ?? throw new EntityNotFoundException();
     }
 
     public async Task<PaginationModel<Car>> GetTunesByIdAsync(Guid Id, int page, int pageSize)
     {
-        var result = await _repository.GetByIdWithDesigns(Id).PaginateAsync(page, pageSize);
-
-        if (result == null)
-        {
-            throw new EntityNotFoundException();
-        }
-
-        return result;
+        return await _repository.GetByIdWithDesigns(Id).PaginateAsync(page, pageSize) ?? throw new EntityNotFoundException();
     }
 
-    public async Task<Car> UpdateAsync(Car newEntity)
+    public async Task<Car> UpdateAsync(Car newEntity, IFormFile thumbnail)
     {
-        var oldEntity = await _repository.GetById(newEntity.Id).FirstOrDefaultAsync();
+        var oldEntity = await _repository.GetById(newEntity.Id).FirstOrDefaultAsync() ?? throw new EntityNotFoundException();
 
-        if (oldEntity == null)
+        string path = Path.Combine(_configuration["Images:Cars"], oldEntity.Id.ToString());
+        using (var stream = new FileStream(path, FileMode.Create))
         {
-            throw new EntityNotFoundException();
+            await thumbnail.CopyToAsync(stream);
         }
 
         oldEntity.Model = newEntity.Model;
         oldEntity.Year = newEntity.Year;
         oldEntity.Price = newEntity.Price;
+        oldEntity.ImagePath = path;
         oldEntity.ManufactureId = newEntity.ManufactureId;
         oldEntity.CarTypeId = newEntity.CarTypeId;
         await _repository.SaveAsync();
 
         return oldEntity;
+    }
+
+    public override async Task Delete(Guid id)
+    {
+        var entity = await _repository.GetById(id).FirstAsync() ?? throw new EntityNotFoundException();
+
+        File.Delete(entity.ImagePath);
+
+        _repository.Delete(entity);
+        await _repository.SaveAsync();
     }
 }

--- a/PocketForzaHorizonCommunity.Back/PocketForzaHorizonCommunity.Back.Services/Services/CarTypeService.cs
+++ b/PocketForzaHorizonCommunity.Back/PocketForzaHorizonCommunity.Back.Services/Services/CarTypeService.cs
@@ -6,7 +6,7 @@ using PocketForzaHorizonCommunity.Back.Services.Services.Interfaces;
 
 namespace PocketForzaHorizonCommunity.Back.Services.Services;
 
-public class CarTypeService : ServiceBase<ICarTypeRepository, CarType>, ICarTypeService
+public class CarTypeService : CrudServiceBase<ICarTypeRepository, CarType>, ICarTypeService
 {
     public CarTypeService(ICarTypeRepository repository) : base(repository)
     {

--- a/PocketForzaHorizonCommunity.Back/PocketForzaHorizonCommunity.Back.Services/Services/CrudServiceBase.cs
+++ b/PocketForzaHorizonCommunity.Back/PocketForzaHorizonCommunity.Back.Services/Services/CrudServiceBase.cs
@@ -8,10 +8,10 @@ using PocketForzaHorizonCommunity.Back.Services.Services.Interfaces;
 
 namespace PocketForzaHorizonCommunity.Back.Services.Services;
 
-public abstract class ServiceBase<TRepo, TEntity> : IServiceBase<TEntity> where TEntity : EntityBase where TRepo : IRepositoryBase<TEntity>
+public abstract class CrudServiceBase<TRepo, TEntity> : ICrudServiceBase<TEntity> where TEntity : EntityBase where TRepo : IRepositoryBase<TEntity>
 {
     protected TRepo _repository;
-    public ServiceBase(TRepo repository)
+    public CrudServiceBase(TRepo repository)
     {
         _repository = repository;
     }
@@ -23,14 +23,7 @@ public abstract class ServiceBase<TRepo, TEntity> : IServiceBase<TEntity> where 
 
     public virtual async Task<TEntity> GetByIdAsync(Guid Id)
     {
-        var entity = await _repository.GetById(Id).FirstOrDefaultAsync();
-
-        if (entity == null)
-        {
-            throw new EntityNotFoundException();
-        }
-
-        return entity;
+        return await _repository.GetById(Id).FirstOrDefaultAsync() ?? throw new EntityNotFoundException();
     }
 
     public virtual async Task<TEntity> CreateAsync(TEntity entity)
@@ -43,12 +36,7 @@ public abstract class ServiceBase<TRepo, TEntity> : IServiceBase<TEntity> where 
 
     public virtual async Task DeleteAsync(Guid id)
     {
-        var entity = await _repository.GetById(id).FirstOrDefaultAsync();
-
-        if (entity == null)
-        {
-            throw new EntityNotFoundException();
-        }
+        var entity = await _repository.GetById(id).FirstOrDefaultAsync() ?? throw new EntityNotFoundException();
 
         _repository.Delete(entity);
         await _repository.SaveAsync();

--- a/PocketForzaHorizonCommunity.Back/PocketForzaHorizonCommunity.Back.Services/Services/Interfaces/ICarService.cs
+++ b/PocketForzaHorizonCommunity.Back/PocketForzaHorizonCommunity.Back.Services/Services/Interfaces/ICarService.cs
@@ -1,12 +1,13 @@
-﻿using PocketForzaHorizonCommunity.Back.Database;
+﻿using Microsoft.AspNetCore.Http;
+using PocketForzaHorizonCommunity.Back.Database;
 using PocketForzaHorizonCommunity.Back.Database.Entities.CarEntities;
 
 namespace PocketForzaHorizonCommunity.Back.Services.Services.Interfaces
 {
-    public interface ICarService : IServiceBase<Car>
+    public interface ICarService : ServiceWithFilesBase<Car>
     {
         Task<PaginationModel<Car>> GetDesignsByIdAsync(Guid id, int page, int pageSize);
         Task<PaginationModel<Car>> GetTunesByIdAsync(Guid Id, int page, int pageSize);
-        Task<Car> UpdateAsync(Car newEntity);
+        Task<Car> UpdateAsync(Car newEntity, IFormFile thumbnail);
     }
 }

--- a/PocketForzaHorizonCommunity.Back/PocketForzaHorizonCommunity.Back.Services/Services/Interfaces/ICarTypeService.cs
+++ b/PocketForzaHorizonCommunity.Back/PocketForzaHorizonCommunity.Back.Services/Services/Interfaces/ICarTypeService.cs
@@ -2,7 +2,7 @@
 
 namespace PocketForzaHorizonCommunity.Back.Services.Services.Interfaces
 {
-    public interface ICarTypeService : IServiceBase<CarType>
+    public interface ICarTypeService : ICrudServiceBase<CarType>
     {
         Task<CarType> UpdateAsync(CarType newCarType);
     }

--- a/PocketForzaHorizonCommunity.Back/PocketForzaHorizonCommunity.Back.Services/Services/Interfaces/ICrudServiceBase.cs
+++ b/PocketForzaHorizonCommunity.Back/PocketForzaHorizonCommunity.Back.Services/Services/Interfaces/ICrudServiceBase.cs
@@ -3,7 +3,7 @@ using PocketForzaHorizonCommunity.Back.Database.Entities;
 
 namespace PocketForzaHorizonCommunity.Back.Services.Services.Interfaces
 {
-    public interface IServiceBase<TEntity> where TEntity : EntityBase
+    public interface ICrudServiceBase<TEntity> where TEntity : EntityBase
     {
         Task<TEntity> CreateAsync(TEntity entity);
         Task DeleteAsync(Guid id);

--- a/PocketForzaHorizonCommunity.Back/PocketForzaHorizonCommunity.Back.Services/Services/Interfaces/IManufactureService.cs
+++ b/PocketForzaHorizonCommunity.Back/PocketForzaHorizonCommunity.Back.Services/Services/Interfaces/IManufactureService.cs
@@ -2,7 +2,7 @@
 
 namespace PocketForzaHorizonCommunity.Back.Services.Services.Interfaces
 {
-    public interface IManufactureService : IServiceBase<Manufacture>
+    public interface IManufactureService : ICrudServiceBase<Manufacture>
     {
         Task<Manufacture> UpdateAsync(Manufacture newManufacture);
     }

--- a/PocketForzaHorizonCommunity.Back/PocketForzaHorizonCommunity.Back.Services/Services/Interfaces/IServiceWithFilesBase.cs
+++ b/PocketForzaHorizonCommunity.Back/PocketForzaHorizonCommunity.Back.Services/Services/Interfaces/IServiceWithFilesBase.cs
@@ -1,0 +1,14 @@
+﻿using Microsoft.AspNetCore.Http;
+using PocketForzaHorizonCommunity.Back.Database;
+using PocketForzaHorizonCommunity.Back.Database.Entities;
+
+namespace PocketForzaHorizonCommunity.Back.Services.Services.Interfaces
+{
+    public interface ServiceWithFilesBase<TEntity> where TEntity : EntityBase
+    {
+        Task<TEntity> CreateAsync(TEntity entity, IFormFile thumbnail);
+        Task Delete(Guid id);
+        Task<PaginationModel<TEntity>> GetAllAsync(int page, int pageSize);
+        Task<TEntity> GetById(Guid id);
+    }
+}

--- a/PocketForzaHorizonCommunity.Back/PocketForzaHorizonCommunity.Back.Services/Services/Interfaces/ITuneService.cs
+++ b/PocketForzaHorizonCommunity.Back/PocketForzaHorizonCommunity.Back.Services/Services/Interfaces/ITuneService.cs
@@ -2,7 +2,7 @@
 
 namespace PocketForzaHorizonCommunity.Back.Services.Services.Interfaces;
 
-public interface ITuneService : IServiceBase<Tune>
+public interface ITuneService : ICrudServiceBase<Tune>
 {
 
 }

--- a/PocketForzaHorizonCommunity.Back/PocketForzaHorizonCommunity.Back.Services/Services/ManufactureService.cs
+++ b/PocketForzaHorizonCommunity.Back/PocketForzaHorizonCommunity.Back.Services/Services/ManufactureService.cs
@@ -6,7 +6,7 @@ using PocketForzaHorizonCommunity.Back.Services.Services.Interfaces;
 
 namespace PocketForzaHorizonCommunity.Back.Services.Services;
 
-public class ManufactureService : ServiceBase<IManufactureRepository, Manufacture>, IManufactureService
+public class ManufactureService : CrudServiceBase<IManufactureRepository, Manufacture>, IManufactureService
 {
     public ManufactureService(IManufactureRepository repository) : base(repository)
     {

--- a/PocketForzaHorizonCommunity.Back/PocketForzaHorizonCommunity.Back.Services/Services/ServiceWithFilesBase.cs
+++ b/PocketForzaHorizonCommunity.Back/PocketForzaHorizonCommunity.Back.Services/Services/ServiceWithFilesBase.cs
@@ -1,0 +1,36 @@
+﻿using Microsoft.AspNetCore.Http;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Configuration;
+using PocketForzaHorizonCommunity.Back.Database;
+using PocketForzaHorizonCommunity.Back.Database.Entities;
+using PocketForzaHorizonCommunity.Back.Database.Repos.Interfaces;
+using PocketForzaHorizonCommunity.Back.Services.Exceptions;
+using PocketForzaHorizonCommunity.Back.Services.Extensions;
+using PocketForzaHorizonCommunity.Back.Services.Services.Interfaces;
+
+namespace PocketForzaHorizonCommunity.Back.Services.Services;
+
+public abstract class ServiceWithFilesBase<TRepo, TEntity> : ServiceWithFilesBase<TEntity> where TEntity : EntityBase where TRepo : IRepositoryBase<TEntity>
+{
+    protected readonly IConfiguration _configuration;
+    protected readonly TRepo _repository;
+    public ServiceWithFilesBase(TRepo repository, IConfiguration config)
+    {
+        _repository = repository;
+        _configuration = config;
+    }
+
+    public virtual async Task<PaginationModel<TEntity>> GetAllAsync(int page, int pageSize)
+    {
+        return await _repository.GetAll().PaginateAsync(page, pageSize);
+    }
+
+    public virtual async Task<TEntity> GetById(Guid id)
+    {
+        return await _repository.GetById(id).FirstOrDefaultAsync() ?? throw new EntityNotFoundException();
+    }
+
+    public abstract Task<TEntity> CreateAsync(TEntity entity, IFormFile thumbnail);
+
+    public abstract Task Delete(Guid id);
+}

--- a/PocketForzaHorizonCommunity.Back/PocketForzaHorizonCommunity.Back.Services/Services/TuneService.cs
+++ b/PocketForzaHorizonCommunity.Back/PocketForzaHorizonCommunity.Back.Services/Services/TuneService.cs
@@ -4,7 +4,7 @@ using PocketForzaHorizonCommunity.Back.Services.Services.Interfaces;
 
 namespace PocketForzaHorizonCommunity.Back.Services.Services;
 
-public class TuneService : ServiceBase<ITuneRepository, Tune>, ITuneService
+public class TuneService : CrudServiceBase<ITuneRepository, Tune>, ITuneService
 {
     public TuneService(ITuneRepository repository) : base(repository)
     {

--- a/PocketForzaHorizonCommunity.Back/PocketForzaHorizonComunity.Back.DTO/Mapper/CarProfile.cs
+++ b/PocketForzaHorizonCommunity.Back/PocketForzaHorizonComunity.Back.DTO/Mapper/CarProfile.cs
@@ -11,7 +11,8 @@ public class CarProfile : Profile
     {
         CreateMap<Car, CarDto>()
             .ForMember(dest => dest.Manufacture, opt => opt.MapFrom(src => src.Manufacture.Name))
-            .ForMember(dest => dest.Type, opt => opt.MapFrom(src => src.CarType.Name));
+            .ForMember(dest => dest.Type, opt => opt.MapFrom(src => src.CarType.Name))
+            .ForMember(dest => dest.Image, opt => opt.MapFrom(src => LoadImage(src.ImagePath)));
 
         CreateMap<CreateCarRequest, Car>()
             .ForMember(dest => dest.ManufactureId, opt => opt.MapFrom(src => Guid.Parse(src.ManufactureId)))
@@ -20,5 +21,16 @@ public class CarProfile : Profile
         CreateMap<UpdateCarRequest, Car>()
             .ForMember(dest => dest.ManufactureId, opt => opt.MapFrom(src => Guid.Parse(src.ManufactureId)))
             .ForMember(dest => dest.CarTypeId, opt => opt.MapFrom(src => Guid.Parse(src.CarTypeId)));
+    }
+
+    private byte[] LoadImage(string path)
+    {
+        using (var stream = new FileStream(path, FileMode.Open))
+        {
+            var image = new byte[stream.Length];
+            stream.Read(image);
+            return image;
+        }
+
     }
 }

--- a/PocketForzaHorizonCommunity.Back/PocketForzaHorizonComunity.Back.DTO/Requests/Car/CreateCarRequest.cs
+++ b/PocketForzaHorizonCommunity.Back/PocketForzaHorizonComunity.Back.DTO/Requests/Car/CreateCarRequest.cs
@@ -1,10 +1,13 @@
-﻿namespace PocketForzaHorizonCommunity.Back.DTO.Requests.Car;
+﻿using Microsoft.AspNetCore.Http;
+
+namespace PocketForzaHorizonCommunity.Back.DTO.Requests.Car;
 
 public class CreateCarRequest
 {
     public string Model { get; set; } = null!;
     public int Year { get; set; }
     public int Price { get; set; }
+    public IFormFile Image { get; set; } = null!;
     public string ManufactureId { get; set; } = null!;
     public string CarTypeId { get; set; } = null!;
 }

--- a/PocketForzaHorizonCommunity.Back/PocketForzaHorizonComunity.Back.DTO/Requests/Car/UpdateCarRequest.cs
+++ b/PocketForzaHorizonCommunity.Back/PocketForzaHorizonComunity.Back.DTO/Requests/Car/UpdateCarRequest.cs
@@ -1,4 +1,6 @@
-﻿namespace PocketForzaHorizonCommunity.Back.DTO.Requests.Car;
+﻿using Microsoft.AspNetCore.Http;
+
+namespace PocketForzaHorizonCommunity.Back.DTO.Requests.Car;
 
 public class UpdateCarRequest
 {
@@ -6,6 +8,7 @@ public class UpdateCarRequest
     public string Model { get; set; } = null!;
     public int Year { get; set; }
     public int Price { get; set; }
+    public IFormFile Image { get; set; } = null!;
     public string ManufactureId { get; set; } = null!;
     public string CarTypeId { get; set; } = null!;
 }


### PR DESCRIPTION
So, I split ServiceBase into CrudServiceBase and ServiceWithFilesBase.
With this splitting I achieve simpler structure of services: car and design services (that works with images) still have their base class with no need to override or overload base methods, like Get and also now have access to configuration file, where image folder path will store.
All other services have no changes.