### PR TITLE
Add a lazy loading attribute to all images, that not a LCP

### DIFF
--- a/forza-horizon-community.front/src/components/CarTableComponent/CarTableComponent.tsx
+++ b/forza-horizon-community.front/src/components/CarTableComponent/CarTableComponent.tsx
@@ -67,6 +67,7 @@ const CarTableComponent = ({ ...props }) => {
                     <Image
                       alt="car"
                       src={imageUtil.addJpgHeader(car.image)}
+                      loading="lazy"
                       width={
                         isTablet
                           ? defaultCarThumbnailSize.width

--- a/forza-horizon-community.front/src/components/DesignDetailsComponent/components/DesignDetailsBodyComponent/DesignDetailsBodyComponent.tsx
+++ b/forza-horizon-community.front/src/components/DesignDetailsComponent/components/DesignDetailsBodyComponent/DesignDetailsBodyComponent.tsx
@@ -45,6 +45,7 @@ const DesignDetailsBodyComponent = ({ description, gallery }: IDesignDetailsBody
                 <Image
                   alt="image"
                   src={imageUtil.addJpgHeader(item)}
+                  loading="lazy"
                   fill
                   className={classes.image}
                 />

--- a/forza-horizon-community.front/src/components/GuideDetailsHeader/GuideDetailsHeader.tsx
+++ b/forza-horizon-community.front/src/components/GuideDetailsHeader/GuideDetailsHeader.tsx
@@ -21,6 +21,7 @@ const GuideDetailsHeader = ({
             <Image
               alt="thumbnail"
               src={thumbnail || "/TuneThumbnail.png"}
+              loading="lazy"
               fill
               style={{ objectFit: "contain" }}
             />

--- a/forza-horizon-community.front/src/components/ImageUploaderComponent/ImageUploaderComponent.tsx
+++ b/forza-horizon-community.front/src/components/ImageUploaderComponent/ImageUploaderComponent.tsx
@@ -65,10 +65,10 @@ const ImageUploaderComponent = ({
             {preview.map((image, index) => (
               <ImageListItem key={index}>
                 {isFixedSize ? (
-                  <Image alt="image" src={image} width={width} height={height} />
+                  <Image alt="image" src={image} loading="lazy" width={width} height={height} />
                 ) : (
                   <Box sx={styles.imageBox}>
-                    <Image alt="image" src={image} fill className={classes.image} />
+                    <Image alt="image" src={image} loading="lazy" fill className={classes.image} />
                   </Box>
                 )}
               </ImageListItem>

--- a/forza-horizon-community.front/src/components/NavBarComponent/NavBarComponent.tsx
+++ b/forza-horizon-community.front/src/components/NavBarComponent/NavBarComponent.tsx
@@ -36,7 +36,7 @@ const NavBarComponent = ({ ...props }) => {
           height={{ xs: 75, md: 100 }}
           position="relative"
         >
-          <Image alt="logo" src="/logo.png" fill style={{ objectFit: "cover" }} />
+          <Image alt="logo" src="/logo.png" loading="lazy" fill style={{ objectFit: "cover" }} />
         </CustomLinkComponent>
         <Box flexGrow={"1"} />
         {isLogged ? <AuthorizedNavbarBodyComponent /> : <AnonymouseNavbarBodyComponent />}

--- a/forza-horizon-community.front/src/components/StatisticsComponent/components/AchievementStatisticsComponent/components/AchievementItemComponent/AchievementItemComponent.tsx
+++ b/forza-horizon-community.front/src/components/StatisticsComponent/components/AchievementStatisticsComponent/components/AchievementItemComponent/AchievementItemComponent.tsx
@@ -7,7 +7,13 @@ import { IAchievementItemComponentProps } from "./types";
 const AchievementItemComponent = ({ achievement, ...props }: IAchievementItemComponentProps) => {
   return (
     <Box sx={styles.achievementContainer}>
-      <Image alt="icon" src={achievement.icon} width={defaultIconSize} height={defaultIconSize} />
+      <Image
+        alt="icon"
+        src={achievement.icon}
+        loading="lazy"
+        width={defaultIconSize}
+        height={defaultIconSize}
+      />
       <Typography variant="textTitle" align="center">
         {achievement.displayName}
       </Typography>

--- a/forza-horizon-community.front/src/components/TuneDetailsComponent/components/TuneDetailsBodyComponent/components/DrivetrainDetailsComponent/DrivetrainDetailsComponent.tsx
+++ b/forza-horizon-community.front/src/components/TuneDetailsComponent/components/TuneDetailsBodyComponent/components/DrivetrainDetailsComponent/DrivetrainDetailsComponent.tsx
@@ -32,6 +32,7 @@ const DrivetrainDetailsComponent = ({
           <Image
             alt={"ClutchIcon"}
             src="/EnumIcons/ClutchIcon.png"
+            loading="lazy"
             width={defaultIconSize}
             height={defaultIconSize}
           />
@@ -43,6 +44,7 @@ const DrivetrainDetailsComponent = ({
           <Image
             alt={"TransmissionIcon"}
             src="/EnumIcons/TransmissionIcon.png"
+            loading="lazy"
             width={defaultIconSize}
             height={defaultIconSize}
           />
@@ -54,6 +56,7 @@ const DrivetrainDetailsComponent = ({
           <Image
             alt={"DifferentialIcon"}
             src="/EnumIcons/DifferentialIcon.png"
+            loading="lazy"
             width={defaultIconSize}
             height={defaultIconSize}
           />

--- a/forza-horizon-community.front/src/components/TuneDetailsComponent/components/TuneDetailsBodyComponent/components/EngineDetailsComponent/EngineDetailsComponent.tsx
+++ b/forza-horizon-community.front/src/components/TuneDetailsComponent/components/TuneDetailsBodyComponent/components/EngineDetailsComponent/EngineDetailsComponent.tsx
@@ -38,6 +38,7 @@ const EngineDetailsComponent = ({
           <Image
             alt={"EngineIcon"}
             src="/EnumIcons/EngineIcon.png"
+            loading="lazy"
             width={defaultIconSize}
             height={defaultIconSize}
           />
@@ -49,6 +50,7 @@ const EngineDetailsComponent = ({
           <Image
             alt={"AspirationIcon"}
             src="/EnumIcons/AspirationIcon.png"
+            loading="lazy"
             width={defaultIconSize}
             height={defaultIconSize}
           />
@@ -60,6 +62,7 @@ const EngineDetailsComponent = ({
           <Image
             alt={"IntakeIcon"}
             src="/EnumIcons/IntakeIcon.png"
+            loading="lazy"
             width={defaultIconSize}
             height={defaultIconSize}
           />
@@ -71,6 +74,7 @@ const EngineDetailsComponent = ({
           <Image
             alt={"IgnitionIcon"}
             src="/EnumIcons/IgnitionIcon.png"
+            loading="lazy"
             width={defaultIconSize}
             height={defaultIconSize}
           />
@@ -82,6 +86,7 @@ const EngineDetailsComponent = ({
           <Image
             alt={"DisplacementIcon"}
             src="/EnumIcons/DisplacementIcon.png"
+            loading="lazy"
             width={defaultIconSize}
             height={defaultIconSize}
           />
@@ -93,6 +98,7 @@ const EngineDetailsComponent = ({
           <Image
             alt={"ExhaustIcon"}
             src="/EnumIcons/ExhaustIcon.png"
+            loading="lazy"
             width={defaultIconSize}
             height={defaultIconSize}
           />

--- a/forza-horizon-community.front/src/components/TuneDetailsComponent/components/TuneDetailsBodyComponent/components/HandlingDetailsComponent/HandlingDetailsComponent.tsx
+++ b/forza-horizon-community.front/src/components/TuneDetailsComponent/components/TuneDetailsBodyComponent/components/HandlingDetailsComponent/HandlingDetailsComponent.tsx
@@ -34,6 +34,7 @@ const HandlingDetailsComponent = ({
           <Image
             alt={"BrakesIcon"}
             src="/EnumIcons/BrakesIcon.png"
+            loading="lazy"
             width={defaultIconSize}
             height={defaultIconSize}
           />
@@ -45,6 +46,7 @@ const HandlingDetailsComponent = ({
           <Image
             alt={"SuspensionIcon"}
             src="/EnumIcons/SuspensionIcon.png"
+            loading="lazy"
             width={defaultIconSize}
             height={defaultIconSize}
           />
@@ -56,6 +58,7 @@ const HandlingDetailsComponent = ({
           <Image
             alt={"AntiRollBarsIcon"}
             src="/EnumIcons/AntiRollBarsIcon.png"
+            loading="lazy"
             width={defaultIconSize}
             height={defaultIconSize}
           />
@@ -67,6 +70,7 @@ const HandlingDetailsComponent = ({
           <Image
             alt={"RollCageIcon"}
             src="/EnumIcons/RollCageIcon.png"
+            loading="lazy"
             width={defaultIconSize}
             height={defaultIconSize}
           />

--- a/forza-horizon-community.front/src/components/TuneDetailsComponent/components/TuneDetailsBodyComponent/components/TiresDetailsComponent/TiresDetailsComponent.tsx
+++ b/forza-horizon-community.front/src/components/TuneDetailsComponent/components/TuneDetailsBodyComponent/components/TiresDetailsComponent/TiresDetailsComponent.tsx
@@ -34,6 +34,7 @@ const TiresDetailsComponent = ({
           <Image
             alt={"TireWidthIcon"}
             src="/EnumIcons/TiresWidthIcon.png"
+            loading="lazy"
             width={defaultIconSize}
             height={defaultIconSize}
           />
@@ -45,6 +46,7 @@ const TiresDetailsComponent = ({
           <Image
             alt={"TireWidthIcon"}
             src="/EnumIcons/TiresWidthIcon.png"
+            loading="lazy"
             width={defaultIconSize}
             height={defaultIconSize}
           />
@@ -56,6 +58,7 @@ const TiresDetailsComponent = ({
           <Image
             alt={"frontTrackWidthIcon"}
             src="/EnumIcons/FrontTrackWidthIcon.png"
+            loading="lazy"
             width={defaultIconSize}
             height={defaultIconSize}
           />
@@ -67,6 +70,7 @@ const TiresDetailsComponent = ({
           <Image
             alt={"rearTrackWidthIcon"}
             src="/EnumIcons/RearTrackWidthIcon.png"
+            loading="lazy"
             width={defaultIconSize}
             height={defaultIconSize}
           />
@@ -78,6 +82,7 @@ const TiresDetailsComponent = ({
           <Image
             alt={"TiresCompoundIcon"}
             src="/EnumIcons/TiresCompoundIcon.png"
+            loading="lazy"
             width={defaultIconSize}
             height={defaultIconSize}
           />

--- a/forza-horizon-community.front/src/components/forms/AddNewTuneFormComponent/components/SparePartSelectComponent/SparePartSelectComponent.tsx
+++ b/forza-horizon-community.front/src/components/forms/AddNewTuneFormComponent/components/SparePartSelectComponent/SparePartSelectComponent.tsx
@@ -22,6 +22,7 @@ const SparePartSelectComponent = ({
       <Image
         alt={imageSrc}
         src={`/EnumIcons/${imageSrc}`}
+        loading="lazy"
         width={defaultIconSize}
         height={defaultIconSize}
         priority

--- a/forza-horizon-community.front/src/components/forms/components/FormHeaderComponent/FormHeaderComponent.tsx
+++ b/forza-horizon-community.front/src/components/forms/components/FormHeaderComponent/FormHeaderComponent.tsx
@@ -6,7 +6,7 @@ import { IFormHeaderComponentProps } from "./types";
 const FormHeaderComponent = ({ text }: IFormHeaderComponentProps) => {
   return (
     <Box sx={styles.outerContainer}>
-      <Image alt="logo" src="/logo.png" width={150} height={100} />
+      <Image alt="logo" src="/logo.png" loading="lazy" width={150} height={100} />
       <Typography variant="imageHeader" textAlign={"center"}>
         {text}
       </Typography>


### PR DESCRIPTION
According to a documentation, loading="lazy" is a default state for an <Image/> component, but I've decided to add this attribute manually, so I'll be sure about its presence 